### PR TITLE
Make middleware class accept a class and enforce original state purity

### DIFF
--- a/lib/smash_the_state/version.rb
+++ b/lib/smash_the_state/version.rb
@@ -1,3 +1,3 @@
 module SmashTheState
-  VERSION = "1.4.3".freeze
+  VERSION = "1.4.4".freeze
 end


### PR DESCRIPTION
* middleware can now return a real module or class, not just a string
* original state is now frozen to enforce its purity