### PR TITLE
add support for specifying array/list schemas

### DIFF
--- a/lib/smash_the_state/operation/state.rb
+++ b/lib/smash_the_state/operation/state.rb
@@ -97,6 +97,7 @@ module SmashTheState
           indifferent_whitelisted_attributes.key? attribute
         end
 
+        return whitelisted_attributes.map { |a| super(a) } if whitelisted_attributes.is_a? Array
         super(whitelisted_attributes)
       end
 

--- a/lib/smash_the_state/operation/state_type.rb
+++ b/lib/smash_the_state/operation/state_type.rb
@@ -1,13 +1,28 @@
 module SmashTheState
   class Operation
     class StateType < ActiveModel::Type::Value
-      def initialize(block)
+      def initialize(block, options)
         @schema_class = Operation::State.build(&block)
+        @is_array = options[:array]
       end
 
       private
 
+      def array?
+        @is_array == true
+      end
+
+      def wrap_array(value)
+        return value if value.is_a? Array
+        [value]
+      end
+
       def cast_value(attributes)
+        return wrap_array(attributes).map { |a| _cast_value(a) } if array?
+        _cast_value(attributes)
+      end
+
+      def _cast_value(attributes)
         @schema_class.new(attributes)
       end
     end
@@ -15,5 +30,5 @@ module SmashTheState
 end
 
 ActiveModel::Type.register(:state_for_smashing) do |_name, options|
-  SmashTheState::Operation::StateType.new(options[:schema])
+  SmashTheState::Operation::StateType.new(options[:schema], options)
 end

--- a/spec/unit/operation/state_spec.rb
+++ b/spec/unit/operation/state_spec.rb
@@ -40,6 +40,10 @@ describe SmashTheState::Operation::State do
 
           # by reference
           schema :jam, ref: jam_definition
+
+          schema :ingredients, array: true do
+            attribute :kind, :string
+          end
         end
       end
     end
@@ -53,7 +57,11 @@ describe SmashTheState::Operation::State do
           },
           jam: {
             sweetened: false
-          }
+          },
+          ingredients: [
+            { kind: "bran" },
+            { kind: "wallnuts" }
+          ]
         }
       )
     end
@@ -65,6 +73,13 @@ describe SmashTheState::Operation::State do
 
     it "allows for reference of type definitions" do
       expect(instance.bread.jam.sweetened).to eq(false)
+    end
+
+    context "array support" do
+      it "allows arrays" do
+        expect(instance.bread.ingredients).to be_a Array
+        expect(instance.bread.ingredients.map(&:kind)).to eq(["bran", "wallnuts"])
+      end
     end
   end
 


### PR DESCRIPTION
This PR add support for specifying that a given schema can be provided as an  array. I didn't add support for individual attributes as that's not actually supported out of the box by `ActiveModel` (only `ActiveRecord` when using a datastore that supports array types). For end-users that require array individual attributes, they can add a custom `ActiveModel::Type` to achieve that in their application.