### PR TITLE
allow overriding of model_name in a state schema (useful for i18n lookups)

### DIFF
--- a/lib/smash_the_state/operation/state.rb
+++ b/lib/smash_the_state/operation/state.rb
@@ -6,6 +6,8 @@ module SmashTheState
       include ActiveModel::Model
       include ActiveModelAttributes
 
+      DEFAULT_MODEL_NAME = "State".freeze
+
       class Invalid < StandardError
         attr_reader :state
 
@@ -61,8 +63,9 @@ module SmashTheState
           state
         end
 
-        def model_name
-          ActiveModel::Name.new(self, nil, "State")
+        def model_name(model_name = nil)
+          @_model_name = model_name if model_name.present?
+          ActiveModel::Name.new(self, nil, @_model_name || DEFAULT_MODEL_NAME)
         end
 
         private

--- a/spec/unit/operation/state_spec.rb
+++ b/spec/unit/operation/state_spec.rb
@@ -138,4 +138,28 @@ describe SmashTheState::Operation::State do
       end
     end
   end
+
+  describe "self#model_name" do
+    context "when provided with a model name" do
+      let!(:built) do
+        subject.build do
+          model_name "Foo"
+        end
+      end
+
+      it "uses the provided model name" do
+        expect(built.model_name.to_s).to eq("Foo")
+      end
+    end
+
+    context "when not provided a model name" do
+      let!(:built) do
+        subject.build {}
+      end
+
+      it "uses the default model name of 'State'" do
+        expect(built.model_name.to_s).to eq("State")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR introduces the ability to provide a custom `model_name` in a state schema. This is useful when using i18n.

Example:

```
schema do
  model_name "User"

  attribute :name, :string
  # ...
end
```

```
# en.yml

en:
  activemodel:
    attributes:
      user:
        name: "Username"
```

In the above example, the `human_attribute_name` for the schema attribute `:name` would look up  the path `activemodel.attributes.user.name` and would resolve to `Username`.
